### PR TITLE
Set http-bind-address to avoid port conflict with older InfluxDB versions

### DIFF
--- a/pifpaf/drivers/influxdb.py
+++ b/pifpaf/drivers/influxdb.py
@@ -51,6 +51,7 @@ class InfluxDBDriver(drivers.Driver):
             cfg.write("""[meta]
    dir = "%(tempdir)s/meta"
    bind-address = ":51233"
+   http-bind-address = ":51232"
 [admin]
   enabled = false
 [data]


### PR DESCRIPTION
Set http-bind-address to avoid port conflict with older influxDB versions

Fixes #29 