### PR TITLE
Bunch of good stuff ;)

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -2,3 +2,4 @@
 test_command=${PYTHON:-python} -m subunit.run discover -t . pifpaf/tests $LISTOPT $IDOPTION
 test_id_option=--load-list $IDFILE
 test_list_option=--list
+group_regex=pifpaf\.tests\.test_drivers

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
   - sudo npm install s3rver -g
   - wget https://dl.influxdata.com/influxdb/releases/influxdb_0.13.0_amd64.deb
   - sudo dpkg -i influxdb_0.13.0_amd64.deb
+  # zkEnv.sh can't be overriden with the deb version of zookeeper, this workaround that
+  - sudo chmod 777 /var/log/zookeeper
 install:
     # The install requirements in travis virtualenv that will be cached
   - pip install tox-travis .[test]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,16 @@
 language: python
-dist: trusty
+dist: xenial
 sudo: required
 cache: 
-  - apt
   - pip
 python:
     - 2.7
     - 3.4
     - 3.5
-addons:
-  apt:
-    packages:
-    - mongodb-server
-    - mysql-server
-    - rabbitmq-server
-    - redis-server
-    - zookeeper
-    - mongodb
-    - couchdb
-    - couchdb-bin
-    - npm
 before_install:
-  - curl 'https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/release.asc' | sudo apt-key add -
-  - echo deb http://download.ceph.com/debian-hammer/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
-  - sudo apt-get update -yq
-  - sudo apt-get install -yq ceph
-  - sudo gem install fakes3
+  - sudo apt-get -qq update
+  - sudo apt-get install -y mongodb-server mysql-server rabbitmq-server redis-server zookeeper mongodb couchdb couchdb-bin npm ceph librados-dev python-dev gcc
+  # - sudo gem install fakes3  # NOTE(sileht): fakes3 looks not installed correctly
   - sudo npm install s3rver -g
   - wget https://dl.influxdata.com/influxdb/releases/influxdb_0.13.0_amd64.deb
   - sudo dpkg -i influxdb_0.13.0_amd64.deb

--- a/pifpaf/drivers/ceph.py
+++ b/pifpaf/drivers/ceph.py
@@ -94,7 +94,8 @@ mon cluster log file = %(tempdir)s/$cluster.log
 filestore xattr use omap = True
 
 # workaround for ext4 and last Jewel version
-osd max object name len = 1024
+osd max object name len = 256
+osd max object namespace len = 64
 osd op threads = 10
 filestore max sync interval = 10001
 filestore min sync interval = 10000

--- a/pifpaf/drivers/ceph.py
+++ b/pifpaf/drivers/ceph.py
@@ -61,10 +61,11 @@ class CephDriver(drivers.Driver):
         os.makedirs(mondir)
         os.makedirs(osddir)
 
-        if os.path.exists("/dev/shm") and os.access('/dev/shm', os.W_OK):
-            journal_path = "/dev/shm/$cluster-$id-journal"
-        else:
-            journal_path = "%s/osd/$cluster-$id/journal" % self.tempdir
+        # FIXME(sileht): check availible space on /dev/shm
+        # if os.path.exists("/dev/shm") and os.access('/dev/shm', os.W_OK):
+        #     journal_path = "/dev/shm/$cluster-$id-journal"
+        # else:
+        journal_path = "%s/osd/$cluster-$id/journal" % self.tempdir
 
         with open(conffile, "w") as f:
             f.write("""[global]

--- a/pifpaf/drivers/postgresql.py
+++ b/pifpaf/drivers/postgresql.py
@@ -51,7 +51,7 @@ class PostgreSQLDriver(drivers.Driver):
         self._exec([self.pgctl, "-w", "-o",
                     "-k %s -p %d -h \"%s\""
                     % (self.tempdir, self.port, self.host),
-                    "start"])
+                    "start"], allow_debug=False)
         self.addCleanup(self._exec, [self.pgctl, "-w", "stop"])
         self.url = "postgresql://localhost/postgres?host=%s&port=%d" % (
             self.tempdir, self.port)

--- a/pifpaf/drivers/rabbitmq.py
+++ b/pifpaf/drivers/rabbitmq.py
@@ -77,7 +77,7 @@ class RabbitMQDriver(drivers.Driver):
             complete_env.update(self.env)
             c, _ = self._exec(["rabbitmq-server"], env=complete_env,
                               path=self._path,
-                              wait_for_line="Starting broker\.\.\. completed")
+                              wait_for_line=("completed with .* plugins"))
             self.addCleanup(self.kill_node, nodename, ignore_not_exists=True)
             self._process[nodename] = c
         return port

--- a/pifpaf/drivers/zookeeper.py
+++ b/pifpaf/drivers/zookeeper.py
@@ -20,6 +20,9 @@ class ZooKeeperDriver(drivers.Driver):
 
     DEFAULT_PORT = 2181
 
+    PATH = ["/usr/share/zookeeper/bin",
+            "/usr/local/opt/zookeeper/libexec/bin"]
+
     def __init__(self, port=DEFAULT_PORT,
                  **kwargs):
         super(ZooKeeperDriver, self).__init__(**kwargs)
@@ -48,17 +51,14 @@ clientPort=%s""" % (self.tempdir, self.port))
         self.putenv("ZOOCFG", cfgfile, True)
         self.putenv("ZOO_LOG_DIR", logdir, True)
 
-        path = ["/usr/share/zookeeper/bin",
-                "/usr/local/opt/zookeeper/libexec/bin"]
-
         c, _ = self._exec(
             ["zkServer.sh", "start", cfgfile],
             wait_for_line="STARTED",
-            path=path)
+            path=self.PATH)
 
         self.addCleanup(self._exec,
                         ["zkServer.sh", "stop", cfgfile],
-                        path=path)
+                        path=self.PATH)
 
         self.putenv("ZOOKEEPER_PORT", str(self.port))
         self.putenv("URL", "zookeeper://localhost:%d" % self.port)

--- a/pifpaf/tests/test_drivers.py
+++ b/pifpaf/tests/test_drivers.py
@@ -54,9 +54,13 @@ os.environ["PATH"] = ":".join((
 class TestDrivers(testtools.TestCase):
     def setUp(self):
         super(TestDrivers, self).setUp()
-        if os.getenv('PIFPAF_DEBUG'):
-            logging.basicConfig(format="%(levelname)8s [%(name)s] %(message)s",
-                                level=logging.DEBUG)
+        self.logger = self.useFixture(
+            fixtures.FakeLogger(
+                format="%(levelname)8s [%(name)s] %(message)s",
+                level=logging.DEBUG,
+                nuke_handlers=True,
+            )
+        )
 
     def _run(self, cmd):
         self.assertEqual(0, os.system(cmd + " >/dev/null 2>&1"))

--- a/pifpaf/tests/test_drivers.py
+++ b/pifpaf/tests/test_drivers.py
@@ -214,8 +214,9 @@ class TestDrivers(testtools.TestCase):
         self.assertEqual("6380", os.getenv("PIFPAF_REDIS_SENTINEL_PORT"))
         self._run("redis-cli -p %d sentinel master pifpaf" % f.sentinel_port)
 
-    @testtools.skipUnless(spawn.find_executable("zkServer"),
-                          "ZooKeeper not found")
+    @testtools.skipUnless(spawn.find_executable(
+        "zkServer.sh", path=":".join(zookeeper.ZooKeeperDriver.PATH)),
+        "ZooKeeper not found")
     def test_zookeeper(self):
         port = 2182
         f = self.useFixture(zookeeper.ZooKeeperDriver(port=port))

--- a/pifpaf/tests/test_drivers.py
+++ b/pifpaf/tests/test_drivers.py
@@ -38,6 +38,7 @@ from pifpaf.drivers import mysql
 from pifpaf.drivers import postgresql
 from pifpaf.drivers import rabbitmq
 from pifpaf.drivers import redis
+from pifpaf.drivers import s3rver
 from pifpaf.drivers import zookeeper
 
 
@@ -149,7 +150,7 @@ class TestDrivers(testtools.TestCase):
                           "s3rver not found")
     def test_s3rver(self):
         port = 4569
-        self.useFixture(fakes3.FakeS3Driver(port=port))
+        self.useFixture(s3rver.S3rverDriver(port=port))
         self.assertEqual("s3://localhost:%d" % port,
                          os.getenv("PIFPAF_URL"))
         self.assertEqual("http://localhost:%d" % port,

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27,py34,py35,pep8,pypy
 usedevelop = True
 sitepackages = False
 deps = .[test]
-       http://tarballs.openstack.org/gnocchi/gnocchi-master.tar.gz#egg=gnocchi[postgresql,file,ceph,ceph-pre-jewel]
+       http://tarballs.openstack.org/gnocchi/gnocchi-master.tar.gz#egg=gnocchi[postgresql,file,ceph,ceph_recommended_lib]
        http://tarballs.openstack.org/aodh/aodh-master.tar.gz#egg=aodh[postgresql]
        http://tarballs.openstack.org/keystone/keystone-master.tar.gz
 passenv = PIFPAF_DEBUG

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ deps = .[test]
        http://tarballs.openstack.org/gnocchi/gnocchi-master.tar.gz#egg=gnocchi[postgresql,file,ceph,ceph_recommended_lib]
        http://tarballs.openstack.org/aodh/aodh-master.tar.gz#egg=aodh[postgresql]
        http://tarballs.openstack.org/keystone/keystone-master.tar.gz
-passenv = PIFPAF_DEBUG
 commands =
     {toxinidir}/tools/pretty_tox.sh '{posargs}'
 


### PR DESCRIPTION
Fixes object name len limit for last ceph point release.
Don't use /dev/shm for ceph for now (travis have a too small disk)
Adds some useful debug information with --debug is passed. 
And adds some missing deb for travis testing.
Move travis to xenial
Tests not capture logging and print it on failure
Fix the s3rver test
Fix rabbitmq waitline when rabbit is too slow to start