### PR TITLE
travis: fix mysql install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - 3.5
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y mongodb-server mysql-server rabbitmq-server redis-server zookeeper mongodb couchdb couchdb-bin npm ceph librados-dev python-dev gcc
+  - sudo apt-get install -y mongodb-server mysql-server-5.6 rabbitmq-server redis-server zookeeper mongodb couchdb couchdb-bin npm ceph librados-dev python-dev gcc
   # - sudo gem install fakes3  # NOTE(sileht): fakes3 looks not installed correctly
   - sudo npm install s3rver -g
   - wget https://dl.influxdata.com/influxdb/releases/influxdb_0.13.0_amd64.deb


### PR DESCRIPTION
travis pre install part mysql of 5.6, while ubuntu suggest 5.5.

This change enforces 5.6