### PR TITLE
gnocchi: Reduce the metricd delays

### DIFF
--- a/pifpaf/drivers/gnocchi.py
+++ b/pifpaf/drivers/gnocchi.py
@@ -103,6 +103,9 @@ class GnocchiDriver(drivers.Driver):
             f.write("""[storage]
 driver = %s
 %s = %s
+[metricd]
+metric_processing_delay = 1
+metric_cleanup_delay = 1
 [statsd]
 resource_id = %s
 creator = admin


### PR DESCRIPTION
pifpaf is mainly used for testing, waiting 1 or 5 minutes per test
in not fun, so this reduces gnocchi-metricd delays to 1 second.