### PR TITLE
cli: fully segment all environ vars

### DIFF
--- a/pifpaf/tests/test_cli.py
+++ b/pifpaf/tests/test_cli.py
@@ -67,6 +67,8 @@ class TestCli(testtools.TestCase):
                          env[b"export FOOBAR_URL"])
         self.assertEqual(b"\"memcached://localhost:11215\";",
                          env[b"export FOOBAR_MEMCACHED_URL"])
+        self.assertEqual(env[b"export PIFPAF_PID"],
+                         env[b"export FOOBAR_PID"])
 
     @testtools.skipUnless(spawn.find_executable("memcached"),
                           "memcached not found")


### PR DESCRIPTION
When we start multiple pifpaf, it would be easier to call
\<prefix\>_stop to stop all of them. Instead of having to kill all PIDs
manually.