### PR TITLE
gnocchi: Set statd old vars

### DIFF
--- a/pifpaf/drivers/gnocchi.py
+++ b/pifpaf/drivers/gnocchi.py
@@ -129,6 +129,8 @@ metric_cleanup_delay = 1
 [statsd]
 resource_id = %s
 creator = admin
+user_id = admin
+project_id = admin
 [indexer]
 url = %s""" % (storage_driver,
                storage_config_string,


### PR DESCRIPTION
We recently move to creator for statd, but we need to
keep compat with the old statd