### PR TITLE
aodh: use database-url for gnocchi indexer

### DIFF
--- a/pifpaf/drivers/aodh.py
+++ b/pifpaf/drivers/aodh.py
@@ -70,6 +70,7 @@ class AodhDriver(drivers.Driver):
 
         g = self.useFixture(gnocchi.GnocchiDriver(
             port=self.gnocchi_port,
+            indexer_url=self.database_url,
             indexer_port=self.gnocchi_indexer_port,
         ))
 


### PR DESCRIPTION
This allow to not force aodh and gnocchi to use different backend.