### PR TITLE
Wait 10 seconds processes to end, them kill them

### DIFF
--- a/pifpaf/drivers/rabbitmq.py
+++ b/pifpaf/drivers/rabbitmq.py
@@ -77,8 +77,7 @@ class RabbitMQDriver(drivers.Driver):
             complete_env.update(self.env)
             c, _ = self._exec(["rabbitmq-server"], env=complete_env,
                               path=self._path,
-                              wait_for_line=("completed with .* plugins"),
-                              session=True)
+                              wait_for_line=("completed with .* plugins"))
             self.addCleanup(self.kill_node, nodename, ignore_not_exists=True)
             self._process[nodename] = c
         return port

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pbr
 jinja2
 six
 fixtures
+tenacity


### PR DESCRIPTION
This change detach all spawned process from pifpaf.
This allows to cleanly SIGKILL the whole process groups of the spawned
process. So if the process spawn other process that those doesn't end
in a timely fashion we sigkill them too.