### PR TITLE
Enhance process kill

### DIFF
--- a/pifpaf/drivers/postgresql.py
+++ b/pifpaf/drivers/postgresql.py
@@ -35,24 +35,25 @@ class PostgreSQLDriver(drivers.Driver):
     def __init__(self, port=DEFAULT_PORT, host=DEFAULT_HOST,
                  **kwargs):
         super(PostgreSQLDriver, self).__init__(**kwargs)
-        _, pgbindir = self._exec(["pg_config", "--bindir"],
-                                 stdout=True)
-        self.pgctl = os.path.join(pgbindir.strip(), b"pg_ctl")
         self.port = port
         self.host = host
 
     def _setUp(self):
         super(PostgreSQLDriver, self)._setUp()
+        _, pgbindir = self._exec(["pg_config", "--bindir"],
+                                 stdout=True)
+        pgctl = os.path.join(pgbindir.strip(), b"pg_ctl")
+
         self.putenv("PGPORT", str(self.port), True)
         self.putenv("PGHOST", self.tempdir, True)
         self.putenv("PGDATA", self.tempdir, True)
         self.putenv("PGDATABASE", "postgres", True)
-        self._exec([self.pgctl, "-o", "'-A trust'", "initdb"])
-        self._exec([self.pgctl, "-w", "-o",
+        self._exec([pgctl, "-o", "'-A trust'", "initdb"])
+        self._exec([pgctl, "-w", "-o",
                     "-k %s -p %d -h \"%s\""
                     % (self.tempdir, self.port, self.host),
                     "start"], allow_debug=False)
-        self.addCleanup(self._exec, [self.pgctl, "-w", "stop"])
+        self.addCleanup(self._exec, [pgctl, "-w", "stop"])
         self.url = "postgresql://localhost/postgres?host=%s&port=%d" % (
             self.tempdir, self.port)
         self.putenv("URL", self.url)

--- a/pifpaf/tests/test_drivers.py
+++ b/pifpaf/tests/test_drivers.py
@@ -75,6 +75,7 @@ class TestDrivers(testtools.TestCase):
 
     def test_stuck_process(self):
         d = drivers.Driver(debug=True)
+        d.setUp()
         c, _ = d._exec(["bash", "-c",
                         "trap ':' TERM ; echo start; sleep 10000"],
                        wait_for_line="start")


### PR DESCRIPTION
This change changes a bit the kill behavior.

Now we kill the process group is the main process doesn't
return 0.

And once SIGKILL is sent no need to call Popen.wait().
Popen.wait() can deadlock if a process catch SIGKILL.

Remove usage of os.getpgid that can raise NoSuchProcess.
The pgid is always the pid in our case.