### PR TITLE
Update wait_for_line for Kafka 1.0.0 server

### DIFF
--- a/pifpaf/drivers/kafka.py
+++ b/pifpaf/drivers/kafka.py
@@ -88,7 +88,7 @@ group.initial.rebalance.delay.ms=0
                         path=self.DEFAULT_PATH, env=env, ignore_failure=True)
 
         self._exec(['kafka-server-start%s' % suffix, kafka_conf],
-                   wait_for_line='Kafka Server 0.*started',
+                   wait_for_line='[Kafka Server id=0].*started',
                    path=self.DEFAULT_PATH, env=env,
                    forbidden_line_after_start=(2,
                                                "kafka.common.KafkaException"))


### PR DESCRIPTION
The started status line changed from 0.11 to 1.0.0 kafka server release.