### PR TITLE
Set the Cliff namespace

### DIFF
--- a/pifpaf/__main__.py
+++ b/pifpaf/__main__.py
@@ -212,7 +212,7 @@ class PifpafApp(app.App):
         super(PifpafApp, self).__init__(
             "Daemon management tool for testing",
             pbr.version.VersionInfo('pifpaf').version_string(),
-            command_manager=PifpafCommandManager(None))
+            command_manager=PifpafCommandManager("pifpaf"))
 
     def build_option_parser(self, description, version):
         parser = super(PifpafApp, self).build_option_parser(


### PR DESCRIPTION
Setting None as namespace was working by chance. Cliff was using it only
in a method we override. But since 2.10, it uses in some other place.

This change put a valid name as cliff namespace.