### PR TITLE
Replace cliff by click

### DIFF
--- a/pifpaf/drivers/__init__.py
+++ b/pifpaf/drivers/__init__.py
@@ -72,8 +72,8 @@ class Driver(fixtures.Fixture):
         self.putenv("DATA", self.tempdir)
 
     @staticmethod
-    def get_parser(parser):
-        return parser
+    def get_options():
+        return []
 
     def putenv(self, key, value, raw=False):
         if not raw:

--- a/pifpaf/drivers/aodh.py
+++ b/pifpaf/drivers/aodh.py
@@ -41,25 +41,27 @@ class AodhDriver(drivers.Driver):
         self.gnocchi_indexer_port = gnocchi_indexer_port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for Aodh")
-        parser.add_argument("--database-url", help="database URL to use")
-        parser.add_argument("--database-port",
-                            type=int,
-                            default=cls.DEFAULT_PORT_DB,
-                            help="port to use for database")
-        parser.add_argument("--gnocchi-port",
-                            type=int,
-                            default=cls.DEFAULT_PORT_GNOCCHI,
-                            help="port to use for Gnocchi")
-        parser.add_argument("--gnocchi-indexer-port",
-                            type=int,
-                            default=cls.DEFAULT_PORT_GNOCCHI_INDEXER,
-                            help="port to use for Gnocchi indexer")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for Aodh"},
+            {"param_decls": ["--database-url"],
+             "help": "database URL to use"},
+            {"param_decls": ["--database-port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT_DB,
+             "help": "port to use for database"},
+            {"param_decls": ["--gnocchi-port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT_GNOCCHI,
+             "help": "port to use for Gnocchi"},
+            {"param_decls": ["--gnocchi-indexer-port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT_GNOCCHI_INDEXER,
+             "help": "port to use for Gnocchi indexer"},
+        ]
 
     def _setUp(self):
         super(AodhDriver, self)._setUp()

--- a/pifpaf/drivers/ceph.py
+++ b/pifpaf/drivers/ceph.py
@@ -29,12 +29,13 @@ class CephDriver(drivers.Driver):
         self.port = port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for Ceph Monitor")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for Ceph Monitor"},
+        ]
 
     def _setUp(self):
         super(CephDriver, self)._setUp()

--- a/pifpaf/drivers/consul.py
+++ b/pifpaf/drivers/consul.py
@@ -26,12 +26,13 @@ class ConsulDriver(drivers.Driver):
         self.port = port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for consul")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for consul"}
+        ]
 
     def _setUp(self):
         super(ConsulDriver, self)._setUp()

--- a/pifpaf/drivers/couchdb.py
+++ b/pifpaf/drivers/couchdb.py
@@ -26,12 +26,13 @@ class CouchDBDriver(drivers.Driver):
         self.port = port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for couchdb")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for couchdb"}
+        ]
 
     def _setUp(self):
         super(CouchDBDriver, self)._setUp()

--- a/pifpaf/drivers/elasticsearch.py
+++ b/pifpaf/drivers/elasticsearch.py
@@ -25,12 +25,13 @@ class ElasticsearchDriver(drivers.Driver):
         self.port = port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for elasticsearch")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for ElasticSearch"},
+        ]
 
     def _setUp(self):
         super(ElasticsearchDriver, self)._setUp()

--- a/pifpaf/drivers/etcd.py
+++ b/pifpaf/drivers/etcd.py
@@ -32,20 +32,21 @@ class EtcdDriver(drivers.Driver):
         self.cluster = cluster
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for etcd")
-        parser.add_argument("--peer-port",
-                            type=int,
-                            default=cls.DEFAULT_PEER_PORT,
-                            help="port to use for etcd peers")
-        parser.add_argument("--cluster",
-                            action='store_true',
-                            default=cls.DEFAULT_CLUSTER,
-                            help="activate etcd cluster")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for etcd"},
+            {"param_decls": ["--peer-port"],
+             "type": int,
+             "default": cls.DEFAULT_PEER_PORT,
+             "help": "port to use for etcd peeres"},
+            {"param_decls": ["--cluster"],
+             "is_flag": True,
+             "default": cls.DEFAULT_CLUSTER,
+             "help": "activate etcd cluster"},
+        ]
 
     def _setUp(self):
         super(EtcdDriver, self)._setUp()

--- a/pifpaf/drivers/fakes3.py
+++ b/pifpaf/drivers/fakes3.py
@@ -24,12 +24,13 @@ class FakeS3Driver(drivers.Driver):
         self.port = port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for fakes3")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for fakes3"},
+        ]
 
     def _setUp(self):
         super(FakeS3Driver, self)._setUp()

--- a/pifpaf/drivers/gnocchi.py
+++ b/pifpaf/drivers/gnocchi.py
@@ -15,6 +15,8 @@ import shutil
 import uuid
 from distutils import spawn
 
+import click
+
 import six.moves.urllib.parse as urlparse
 
 from pifpaf import drivers
@@ -46,30 +48,32 @@ class GnocchiDriver(drivers.Driver):
         self.coordination_port = coordination_port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for Gnocchi HTTP API")
-        parser.add_argument("--statsd-port",
-                            type=int,
-                            help="port to use for gnocchi-statsd")
-        parser.add_argument("--indexer-port",
-                            type=int,
-                            default=cls.DEFAULT_PORT_INDEXER,
-                            help="port to use for Gnocchi indexer")
-        parser.add_argument("--coordination-port",
-                            type=int,
-                            default=cls.DEFAULT_PORT_COORDINATOR,
-                            help="port to use for Gnocchi coordination")
-        parser.add_argument("--coordination-driver",
-                            default="default",
-                            choices=["default", "redis"],
-                            nargs="?",
-                            help="Select a coordination driver")
-        parser.add_argument("--indexer-url", help="indexer URL to use")
-        parser.add_argument("--storage-url", help="storage URL to use")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for Gnocchi HTTP API"},
+            {"param_decls": ["--statsd-port"],
+             "type": int,
+             "help": "port to use for gnocchi-statsd"},
+            {"param_decls": ["--indexer-port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT_INDEXER,
+             "help": "port to use for Gnocchi indexer"},
+            {"param_decls": ["--coordination-port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT_COORDINATOR,
+             "help": "port to use for Gnocchi coordination"},
+            {"param_decls": ["--coordination-driver"],
+             "type": click.Choice(["default", "redis"]),
+             "default": "default",
+             "help": "Select a coordination driver"},
+            {"param_decls": ["--indexer-url"],
+             "help": "indexer URL to use"},
+            {"param_decls": ["--storage-url"],
+             "help": "storage URL to use"},
+        ]
 
     def _setUp(self):
         super(GnocchiDriver, self)._setUp()

--- a/pifpaf/drivers/influxdb.py
+++ b/pifpaf/drivers/influxdb.py
@@ -30,15 +30,16 @@ class InfluxDBDriver(drivers.Driver):
         self.database = database
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for InfluxDB")
-        parser.add_argument("--database",
-                            default=cls.DEFAULT_DATABASE,
-                            help="database to create for InfluxDB")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for InfluxDB"},
+            {"param_decls": ["--database"],
+             "default": cls.DEFAULT_DATABASE,
+             "help": "database to create for InfluxDB"},
+        ]
 
     def _setUp(self):
         super(InfluxDBDriver, self)._setUp()

--- a/pifpaf/drivers/keystone.py
+++ b/pifpaf/drivers/keystone.py
@@ -31,16 +31,17 @@ class KeystoneDriver(drivers.Driver):
         self.admin_port = admin_port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for Keystone public API")
-        parser.add_argument("--admin-port",
-                            type=int,
-                            default=cls.DEFAULT_ADMIN_PORT,
-                            help="port to use for Keystone admin API")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for Keystone public API"},
+            {"param_decls": ["--admin-port"],
+             "type": int,
+             "default": cls.DEFAULT_ADMIN_PORT,
+             "help": "port to use for Keystone admin API"},
+        ]
 
     def _setUp(self):
         super(KeystoneDriver, self)._setUp()

--- a/pifpaf/drivers/memcached.py
+++ b/pifpaf/drivers/memcached.py
@@ -24,12 +24,13 @@ class MemcachedDriver(drivers.Driver):
         self.port = port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for memcached")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for memcached"},
+        ]
 
     def _setUp(self):
         super(MemcachedDriver, self)._setUp()

--- a/pifpaf/drivers/mongodb.py
+++ b/pifpaf/drivers/mongodb.py
@@ -24,12 +24,13 @@ class MongoDBDriver(drivers.Driver):
         self.port = port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for MongoDB")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for MongoDB"},
+        ]
 
     def _setUp(self):
         super(MongoDBDriver, self)._setUp()

--- a/pifpaf/drivers/postgresql.py
+++ b/pifpaf/drivers/postgresql.py
@@ -22,15 +22,16 @@ class PostgreSQLDriver(drivers.Driver):
     DEFAULT_HOST = ""
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for PostgreSQL")
-        parser.add_argument("--host",
-                            default=cls.DEFAULT_HOST,
-                            help="host to listen on")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for PostgreSQL"},
+            {"param_decls": ["--host"],
+             "default": cls.DEFAULT_HOST,
+             "help": "host to listen on"},
+        ]
 
     def __init__(self, port=DEFAULT_PORT, host=DEFAULT_HOST,
                  **kwargs):

--- a/pifpaf/drivers/rabbitmq.py
+++ b/pifpaf/drivers/rabbitmq.py
@@ -43,20 +43,25 @@ class RabbitMQDriver(drivers.Driver):
         self._next_port = itertools.count(self.port)
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for RabbitMQ")
-        parser.add_argument("--nodename", default=cls.DEFAULT_NODENAME,
-                            help="RabbitMQ node name")
-        parser.add_argument("--cluster", action="store_true",
-                            help="Create a 3 HA node clusters")
-        parser.add_argument("--username", default=cls.DEFAULT_USERNAME,
-                            help="RabbitMQ username")
-        parser.add_argument("--password", default=cls.DEFAULT_PASSWORD,
-                            help="RabbitMQ password")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for RabbitMQ"},
+            {"param_decls": ["--nodename"],
+             "default": cls.DEFAULT_NODENAME,
+             "help": "RabbitMQ node name"},
+            {"param_decls": ["--cluster"],
+             "is_flag": True,
+             "help": "Create a 3 HA node clusters"},
+            {"param_decls": ["--username"],
+             "default": cls.DEFAULT_USERNAME,
+             "help": "RabbitMQ username"},
+            {"param_decls": ["--password"],
+             "default": cls.DEFAULT_PASSWORD,
+             "help": "RabbitMQ password"},
+        ]
 
     def get_port(self, nodename):
         if nodename not in self._ports:

--- a/pifpaf/drivers/redis.py
+++ b/pifpaf/drivers/redis.py
@@ -31,20 +31,20 @@ class RedisDriver(drivers.Driver):
         self.sentinel_port = sentinel_port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for Redis")
-        parser.add_argument("--sentinel",
-                            action='store_true',
-                            default=False,
-                            help="activate Redis sentinel")
-        parser.add_argument("--sentinel-port",
-                            type=int,
-                            default=cls.DEFAULT_PORT_SENTINEL,
-                            help="port to use for Redis sentinel")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for Redis"},
+            {"param_decls": ["--sentinel"],
+             "is_flag": True,
+             "help": "activate Redis sentinel"},
+            {"param_decls": ["--sentinel-port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT_SENTINEL,
+             "help": "port to use for Redis sentinel"},
+        ]
 
     def _setUp(self):
         super(RedisDriver, self)._setUp()

--- a/pifpaf/drivers/s3rver.py
+++ b/pifpaf/drivers/s3rver.py
@@ -24,12 +24,13 @@ class S3rverDriver(drivers.Driver):
         self.port = port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for s3rver")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for s3rver"},
+        ]
 
     def _setUp(self):
         super(S3rverDriver, self)._setUp()

--- a/pifpaf/drivers/swift.py
+++ b/pifpaf/drivers/swift.py
@@ -65,28 +65,29 @@ class SwiftDriver(drivers.Driver):
         self.memcached_port = memcached_port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for Swift Proxy Server")
-        parser.add_argument("--object-port",
-                            type=int,
-                            default=cls.DEFAULT_PORT_OBJECT,
-                            help="port to use for Swift Object Server")
-        parser.add_argument("--container-port",
-                            type=int,
-                            default=cls.DEFAULT_PORT_CONTAINER,
-                            help="port to use for Swift Container Server")
-        parser.add_argument("--account-port",
-                            type=int,
-                            default=cls.DEFAULT_PORT_ACCOUNT,
-                            help="port to use for Swift Account Server")
-        parser.add_argument("--memcached-port",
-                            type=int,
-                            default=cls.DEFAULT_PORT_MEMCACHED,
-                            help="port to use for memcached Server")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for Swift Proxy Server"},
+            {"param_decls": ["--object-port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT_OBJECT,
+             "help": "port to use for Swift Object Server"},
+            {"param_decls": ["--container-port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT_CONTAINER,
+             "help": "port to use for Swift Container Server"},
+            {"param_decls": ["--account-port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT_ACCOUNT,
+             "help": "port to use for Swift Account Server"},
+            {"param_decls": ["--memcached-port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT_MEMCACHED,
+             "help": "port to use for memcached server"},
+        ]
 
     def _setUp(self):
         super(SwiftDriver, self)._setUp()

--- a/pifpaf/drivers/vault.py
+++ b/pifpaf/drivers/vault.py
@@ -28,14 +28,15 @@ class VaultDriver(drivers.Driver):
         self.listen_address = listen_address
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--root-token-id",
-                            default=cls.DEFAULT_ROOT_TOKEN_ID,
-                            help="root token for vault")
-        parser.add_argument("--listen-address",
-                            default=cls.DEFAULT_LISTEN_ADDRESS,
-                            help="listen address for vault")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--root-token-id"],
+             "default": cls.DEFAULT_ROOT_TOKEN_ID,
+             "help": "root token for vault"},
+            {"param_decls": ["--listen-address"],
+             "default": cls.DEFAULT_LISTEN_ADDRESS,
+             "help": "listen address for vault"},
+        ]
 
     def _setUp(self):
         super(VaultDriver, self)._setUp()

--- a/pifpaf/drivers/zookeeper.py
+++ b/pifpaf/drivers/zookeeper.py
@@ -29,12 +29,13 @@ class ZooKeeperDriver(drivers.Driver):
         self.port = port
 
     @classmethod
-    def get_parser(cls, parser):
-        parser.add_argument("--port",
-                            type=int,
-                            default=cls.DEFAULT_PORT,
-                            help="port to use for ZooKeeper")
-        return parser
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for ZooKeeper"},
+        ]
 
     def _setUp(self):
         super(ZooKeeperDriver, self)._setUp()

--- a/pifpaf/tests/test_cli.py
+++ b/pifpaf/tests/test_cli.py
@@ -54,6 +54,26 @@ class TestCli(testtools.TestCase):
     @testtools.skipUnless(spawn.find_executable("memcached"),
                           "memcached not found")
     def test_env_prefix(self):
+        c = subprocess.Popen(["pifpaf", "run",
+                              "--env-prefix", "FOOBAR",
+                              "memcached", "--port", "11215"],
+                             bufsize=0,
+                             stdout=subprocess.PIPE)
+        (stdout, stderr) = c.communicate()
+        self.assertEqual(0, c.wait())
+        env = self._read_stdout_and_kill(stdout)
+
+        self.assertEqual(b"\"memcached://localhost:11215\";",
+                         env[b"export FOOBAR_URL"])
+        self.assertEqual(b"\"memcached://localhost:11215\";",
+                         env[b"export FOOBAR_MEMCACHED_URL"])
+        self.assertEqual(env[b"export PIFPAF_PID"],
+                         env[b"export FOOBAR_PID"])
+
+    @testtools.skipUnless(spawn.find_executable("memcached"),
+                          "memcached not found")
+    def test_env_prefix_old_format(self):
+        # Old format
         c = subprocess.Popen(["pifpaf",
                               "--env-prefix", "FOOBAR",
                               "run", "memcached", "--port", "11215"],
@@ -73,6 +93,29 @@ class TestCli(testtools.TestCase):
     @testtools.skipUnless(spawn.find_executable("memcached"),
                           "memcached not found")
     def test_global_urls_varibale(self):
+        c = subprocess.Popen(["pifpaf", "run",
+                              "--env-prefix", "FOOBAR",
+                              "memcached", "--port", "11217",
+                              "--",
+                              "pifpaf",
+                              "run", "memcached", "--port", "11218"],
+                             bufsize=0,
+                             stdout=subprocess.PIPE)
+        (stdout, stderr) = c.communicate()
+        self.assertEqual(0, c.wait())
+        env = self._read_stdout_and_kill(stdout)
+
+        self.assertEqual(b"\"memcached://localhost:11218\";",
+                         env[b"export PIFPAF_URL"])
+        self.assertEqual(b"\"memcached://localhost:11218\";",
+                         env[b"export PIFPAF_MEMCACHED_URL"])
+        self.assertEqual(
+            b"\"memcached://localhost:11217;memcached://localhost:11218\";",
+            env[b"export PIFPAF_URLS"])
+
+    @testtools.skipUnless(spawn.find_executable("memcached"),
+                          "memcached not found")
+    def test_global_urls_varibale_old_format(self):
         c = subprocess.Popen(["pifpaf",
                               "--env-prefix", "FOOBAR",
                               "run", "memcached", "--port", "11217",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 daiquiri
-cliff
+click
 pbr
 jinja2
 six


### PR DESCRIPTION
Cliff is not maintained and barely used (105 GitHub stars), whereas Click is
maintained and is widely used (5k+ stars on Github).

In the context of pifpaf, most of the "interesting" features of cliff are not
used (e.g. output formats), so sticking to a single parser such as click is
far enough.