### PR TITLE
wait the pifpaf process termination in fork mode

### DIFF
--- a/pifpaf/__main__.py
+++ b/pifpaf/__main__.py
@@ -238,13 +238,16 @@ class RunGroup(click.MultiCommand):
                       "if test -z \"$%(prefix)s_PID\"; then "
                       "echo 'No PID found in $%(prefix)s_PID'; return -1; "
                       "fi; "
-                      "if kill $%(prefix)s_PID; then "
+                      "kill $%(prefix)s_PID; "
+                      "while kill -0 $%(prefix)s_PID 2>/dev/null; do"
+                      "  sleep 1 ; "
+                      "done ; "
                       "_PS1=$%(prefix)s_OLD_PS1; "
                       "unset %(vars)s; "
                       "PS1=$_PS1; unset _PS1; "
                       "unset -f %(prefix_lower)s_stop; "
                       "unalias pifpaf_stop 2>/dev/null || true; "
-                      "fi; } ; "
+                      "} ; "
                       "alias pifpaf_stop=%(prefix_lower)s_stop ; "
                       % {"prefix": env_prefix,
                          "prefix_lower":


### PR DESCRIPTION
In fork mode, pifpaf_stop() kill pifpaf and return. When multiple
pifpaf are run in a row this can cause trouble because subprocess of
pifpaf maybe not yet endded.

This change waits for the pifpaf process to exit before returning.