### PR TITLE
make gnocchi use given port

### DIFF
--- a/pifpaf/drivers/gnocchi.py
+++ b/pifpaf/drivers/gnocchi.py
@@ -163,6 +163,9 @@ class GnocchiDriver(drivers.Driver):
             f.write("""[DEFAULT]
 debug = %s
 verbose = True
+[api]
+host = localhost
+port = %s
 [storage]
 driver = %s
 %s
@@ -176,6 +179,7 @@ user_id = admin
 project_id = admin
 [indexer]
 url = %s""" % (self.debug,
+               self.port,
                storage_driver,
                storage_config_string,
                statsd_resource_id,


### PR DESCRIPTION
if gnocchi < 4.1, it correctly leverages given port but if not,
it uses whatever default is as we don't set it in conffile. this
breaks aodh driver as aodh creates gnocchi on a port other than
default.