### PR TITLE
Fix error message if the given command was not found

### DIFF
--- a/pifpaf/drivers/__init__.py
+++ b/pifpaf/drivers/__init__.py
@@ -237,7 +237,7 @@ class Driver(fixtures.Fixture):
             )
         except OSError as e:
             raise RuntimeError(
-                "Unable to run command `%s': %s" % (b" ".join(command), e))
+                "Unable to run command `%s': %s" % (" ".join(command), e))
 
         self.addCleanup(self._kill, c)
 


### PR DESCRIPTION
If the requested command does not exist, pifpaf will fail to create an exception message leaving a new user to a cryptic message of this form:

```
ERROR [pifpaf] sequence item 0: expected a bytes-like object, str found
```