### PR TITLE
ceph: Allow to delete pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   # FIXME(sileht): readd rabbitmq-server when https://github.com/travis-ci/travis-cookbooks/issues/964 and https://github.com/travis-ci/travis-ci/issues/8906 are fixed
   - sudo apt-get install -y mongodb-server mysql-server-5.5 redis-server zookeeper mongodb couchdb couchdb-bin nodejs npm ceph librados-dev python-dev gcc liberasurecode-dev liberasurecode1 postgresql libpq-dev
   # - sudo gem install fakes3  # NOTE(sileht): fakes3 looks not installed correctly
-  - sudo npm install s3rver -g
+  # - sudo npm install s3rver -g
   - wget https://dl.influxdata.com/influxdb/releases/influxdb_0.13.0_amd64.deb
   - sudo dpkg -i influxdb_0.13.0_amd64.deb
   # zkEnv.sh can't be overriden with the deb version of zookeeper, this workaround that

--- a/pifpaf/__main__.py
+++ b/pifpaf/__main__.py
@@ -120,7 +120,7 @@ def main(ctx, verbose=False, debug=False, log_file=None,
 
 
 @main.command(name="list")
-def list():
+def drivers_list():
     for n in DAEMONS:
         click.echo(n)
 

--- a/pifpaf/drivers/ceph.py
+++ b/pifpaf/drivers/ceph.py
@@ -65,7 +65,6 @@ osd_failsafe_full_ratio = 1
 mon_allow_pool_delete = true
 """
 
-
         # FIXME(sileht): check availible space on /dev/shm
         # if os.path.exists("/dev/shm") and os.access('/dev/shm', os.W_OK):
         #     journal_path = "/dev/shm/$cluster-$id-journal"

--- a/pifpaf/drivers/ceph.py
+++ b/pifpaf/drivers/ceph.py
@@ -54,14 +54,17 @@ class CephDriver(drivers.Driver):
         version = pkg_resources.parse_version(version)
 
         if version < pkg_resources.parse_version("12.0.0"):
-            ratio = """
+            extra = """
 mon_osd_nearfull_ratio = 1
 mon_osd_full_ratio = 1
 osd_failsafe_nearfull_ratio = 1
 osd_failsafe_full_ratio = 1
 """
         else:
-            ratio = ""
+            extra = """
+mon_allow_pool_delete = true
+"""
+
 
         # FIXME(sileht): check availible space on /dev/shm
         # if os.path.exists("/dev/shm") and os.access('/dev/shm', os.W_OK):
@@ -103,7 +106,7 @@ osd op threads = 10
 filestore max sync interval = 10001
 filestore min sync interval = 10000
 
-%(ratio)s
+%(extra)s
 
 journal_aio = false
 journal_dio = false
@@ -117,7 +120,7 @@ setuser match path = %(tempdir)s/$type/$cluster-$id
 host = localhost
 mon addr = 127.0.0.1:%(port)d
 """ % dict(fsid=fsid, tempdir=self.tempdir, port=self.port,
-           journal_path=journal_path, ratio=ratio))  # noqa
+           journal_path=journal_path, extra=extra))  # noqa
 
         ceph_opts = ["ceph", "-c", conffile]
         mon_opts = ["ceph-mon", "-c", conffile, "--id", "a", "-d"]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27,py34,py35,py36,pep8,pypy
 usedevelop = True
 sitepackages = False
 deps = .[test,ceph,gnocchi]
-       http://tarballs.openstack.org/gnocchi/gnocchi-master.tar.gz#egg=gnocchi[postgresql,file,ceph,ceph_recommended_lib,s3]
+       gnocchi[postgresql,file,ceph,ceph_recommended_lib,s3]
        http://tarballs.openstack.org/aodh/aodh-master.tar.gz#egg=aodh[postgresql]
        http://tarballs.openstack.org/swift/swift-master.tar.gz#egg=swift
        python-swiftclient


### PR DESCRIPTION
Recent ceph version disallow pool deletion by default.

This breaks cradox testing, this change reallow it.