### PR TITLE
postgresql: add a --sync/--no-sync option

### DIFF
--- a/pifpaf/tests/test_drivers.py
+++ b/pifpaf/tests/test_drivers.py
@@ -245,6 +245,17 @@ class TestDrivers(testtools.TestCase):
             os.getenv("PIFPAF_URL"))
         self._run("psql template1 -c 'CREATE TABLE FOOBAR();'")
 
+    @testtools.skipUnless(spawn.find_executable("pg_config"),
+                          "pg_config not found")
+    def test_postgresql_async(self):
+        port = 9825
+        f = self.useFixture(postgresql.PostgreSQLDriver(port=port, sync=False))
+        self.assertEqual(
+            "postgresql://localhost/postgres?host=%s&port=%d"
+            % (f.tempdir, port),
+            os.getenv("PIFPAF_URL"))
+        self._run("psql template1 -c 'CREATE TABLE FOOBAR();'")
+
     @testtools.skipUnless(spawn.find_executable("redis-server"),
                           "redis-server not found")
     def test_redis(self):


### PR DESCRIPTION
This new --no-sync option configure (partially) the pg server with
non-durable settings, as decribed here

  https://www.postgresql.org/docs/current/non-durability.html

The --sync (default) keep the config file untouched.

Closes #114