### PR TITLE
Fix "expected str instance, bytes found"

### DIFF
--- a/pifpaf/drivers/__init__.py
+++ b/pifpaf/drivers/__init__.py
@@ -237,7 +237,7 @@ class Driver(fixtures.Fixture):
             )
         except OSError as e:
             raise RuntimeError(
-                "Unable to run command `%s': %s" % (" ".join(command), e))
+                "Unable to run command `%s': %s" % (command, e))
 
         self.addCleanup(self._kill, c)
 


### PR DESCRIPTION
Hi,

After a fresh install, I was getting this when running `pifpaf run postgresql`:

```
ERROR [pifpaf] sequence item 0: expected str instance, bytes found
```

This PR turns the error into:

```
ERROR [pifpaf] Unable to run command `[b'/usr/lib/postgresql/9.6/bin/pg_ctl', '-o', "'-A trust'", 'initdb']': [Errno 2] No such file or directory: b'/usr/lib/postgresql/9.6/bin/pg_ctl'
```

Thanks for making pifpaf, btw!