### PR TITLE
Add Ceph config options for small disks

### DIFF
--- a/pifpaf/drivers/ceph.py
+++ b/pifpaf/drivers/ceph.py
@@ -115,6 +115,11 @@ journal block align = false
 # run as file owner
 setuser match path = %(tempdir)s/$type/$cluster-$id
 
+[mon]
+mon pg warn min per osd = 0
+mon data avail warn = 2
+mon data avail crit = 1
+
 [mon.a]
 host = localhost
 mon addr = 127.0.0.1:%(port)d


### PR DESCRIPTION
When running pifpaf on a test machine with
a small amount of disk the deployed Ceph
cluster can permanently enter the HEALT_WARN
state due to warning level being high by default.

This lowers the warning levels and minimum PGs
per OSD so that machines with small disk can be
used.