### PR TITLE
Add a driver for httpbin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ Pifpaf currently supports:
 * `MongoDB`_
 * `OpenStack Swift`_
 * `Vault`_
+* `HttpBin`_
 
 .. _Consul: https://www.consul.io/
 .. _PostgreSQL: http://postgresql.org
@@ -63,6 +64,7 @@ Pifpaf currently supports:
 .. _MongoDB: https://www.mongodb.com
 .. _OpenStack Swift: https://docs.openstack.org/developer/swift/
 .. _Vault: https://www.vaultproject.io/
+.. _HttpBin: https://httpbin.org/
 
 Usage
 =====

--- a/pifpaf/drivers/httpbin.py
+++ b/pifpaf/drivers/httpbin.py
@@ -19,8 +19,7 @@ class HttpBinDriver(drivers.Driver):
 
     DEFAULT_PORT = 5000
 
-    def __init__(self, port=DEFAULT_PORT, ssl_chain_cert=None, ssl_key=None,
-                 ssl_ca_cert=None, **kwargs):
+    def __init__(self, port=DEFAULT_PORT, **kwargs):
         """Create a new httpbin server."""
         super(HttpBinDriver, self).__init__(**kwargs)
         self.port = port
@@ -37,7 +36,8 @@ class HttpBinDriver(drivers.Driver):
     def _setUp(self):
         super(HttpBinDriver, self)._setUp()
 
-        command = [sys.executable, "-m", "httpbin.core", "--port", str(self.port)]
+        command = [sys.executable, "-m", "httpbin.core", "--port",
+                   str(self.port)]
 
         c, _ = self._exec(command, wait_for_port=self.port)
 

--- a/pifpaf/drivers/httpbin.py
+++ b/pifpaf/drivers/httpbin.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import sys
+
 from pifpaf import drivers
 
 

--- a/pifpaf/drivers/httpbin.py
+++ b/pifpaf/drivers/httpbin.py
@@ -1,0 +1,45 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from pifpaf import drivers
+
+
+class HttpBinDriver(drivers.Driver):
+
+    DEFAULT_PORT = 5000
+
+    def __init__(self, port=DEFAULT_PORT, ssl_chain_cert=None, ssl_key=None,
+                 ssl_ca_cert=None, **kwargs):
+        """Create a new httpbin server."""
+        super(HttpBinDriver, self).__init__(**kwargs)
+        self.port = port
+
+    @classmethod
+    def get_options(cls):
+        return [
+            {"param_decls": ["--port"],
+             "type": int,
+             "default": cls.DEFAULT_PORT,
+             "help": "port to use for httpbin"},
+        ]
+
+    def _setUp(self):
+        super(HttpBinDriver, self)._setUp()
+
+        command = [sys.executable, "-m", "httpbin.core", "--port", str(self.port)]
+
+        c, _ = self._exec(command, wait_for_port=self.port)
+
+        self.putenv("HTTPBIN_PORT", str(self.port))
+        self.putenv("URL", "http://127.0.0.1:%d" % self.port)

--- a/pifpaf/tests/test_drivers.py
+++ b/pifpaf/tests/test_drivers.py
@@ -38,6 +38,7 @@ from pifpaf.drivers import elasticsearch
 from pifpaf.drivers import etcd
 from pifpaf.drivers import fakes3
 from pifpaf.drivers import gnocchi
+from pifpaf.drivers import httpbin
 from pifpaf.drivers import influxdb
 from pifpaf.drivers import kafka
 from pifpaf.drivers import keystone
@@ -534,6 +535,16 @@ class TestDrivers(testtools.TestCase):
         self.assertEqual(
             "swift://test%3Atester:testing@localhost:8080/auth/v1.0",
             os.getenv("PIFPAF_URL"))
+
+    @testtools.skipUnless(testtools.try_import('httpbin'),
+                          "httpbin not found")
+    def test_httpbin(self):
+        port = 6666
+        a = self.useFixture(httpbin.HttpBinDriver(port=port))
+        self.assertEqual(port, a.port)
+        r = requests.get("http://127.0.0.1:%d/ip" % port)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["origin"], "127.0.0.1")
 
     def _get_tmpdir_for_xattr(self):
         tmp_rootdir = os.getenv("TMPDIR_FOR_XATTR")

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ test =
     testtools
     os-testr
     mock
-    httpbin
 gnocchi =
     uwsgi
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ test =
     testtools
     os-testr
     mock
+    httpbin
 gnocchi =
     uwsgi
 
@@ -44,6 +45,7 @@ pifpaf.daemons =
     swift = pifpaf.drivers.swift:SwiftDriver
     keystone = pifpaf.drivers.keystone:KeystoneDriver
     kafka = pifpaf.drivers.kafka:KafkaDriver
+    httpbin = pifpaf.drivers.httpbin:HttpBinDriver
     influxdb = pifpaf.drivers.influxdb:InfluxDBDriver
     memcached = pifpaf.drivers.memcached:MemcachedDriver
     mongodb = pifpaf.drivers.mongodb:MongoDBDriver

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps = .[test,ceph,gnocchi]
        python-swiftclient
        tooz[redis]
        http://tarballs.openstack.org/keystone/keystone-master.tar.gz
+       httpbin
 passenv = TMPDIR_FOR_XATTR
 commands =
     {toxinidir}/tools/pretty_tox.sh '--concurrency=1 {posargs}'


### PR DESCRIPTION
Runs httpbin locally for testing, without the need to access external
httpbin.org instance.