### PR TITLE
ceph: set limit for max open fds

### DIFF
--- a/pifpaf/drivers/ceph.py
+++ b/pifpaf/drivers/ceph.py
@@ -88,6 +88,7 @@ osd crush chooseleaf type = 0
 ## some default path change
 run dir = %(tempdir)s
 pid file = %(tempdir)s/$type.$id.pid
+max open files = 1024
 admin socket = %(tempdir)s/$cluster-$name.asok
 mon data = %(tempdir)s/mon/$cluster-$id
 osd data = %(tempdir)s/osd/$cluster-$id


### PR DESCRIPTION
not sure what's changed over years but it seems "newer" versions
has more resource requirements that don't play well with single
node test env. set max open files to try to limit it for testing.

https://github.com/ceph/ceph/blob/master/src/sample.ceph.conf#L51

this doesn't fix https://github.com/gnocchixyz/gnocchi/pull/1068 but it's a start (i think)