### PR TITLE
Fix etcd v3.4 cluster works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ before_install:
   - wget https://archive.apache.org/dist/kafka/2.6.0/kafka_2.12-2.6.0.tgz -O /opt/kafka.tar.gz
   - tar -xzf /opt/kafka.tar.gz -C /opt
   - ln -s /opt/kafka_2.12-2.6.0 /opt/kafka
+  - wget https://github.com/etcd-io/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd64.tar.gz -O /opt/etcd.tar.gz
+  - tar -zxf /opt/etcd.tar.gz -C /opt
+  - ln -s /opt/etcd-v3.4.13-linux-amd64/etcd /opt/etcd
+  - ln -s /opt/etcd-v3.4.13-linux-amd64/etcdctl /opt/etcdctl
 install:
     # The install requirements in travis virtualenv that will be cached
   - pip install tox-travis .[test,ceph]

--- a/pifpaf/drivers/etcd.py
+++ b/pifpaf/drivers/etcd.py
@@ -69,7 +69,7 @@ class EtcdDriver(drivers.Driver):
                                                   for i, (peer_url, client_url)
                                                   in enumerate(http_urls)),
                     "--initial-cluster-state", "new",
-                ], wait_for_line="listening for client requests on")
+                ], wait_for_line="listening for peers on")
 
             endpoints = ",".join(client_url
                                  for peer_url, client_url in http_urls)
@@ -81,7 +81,7 @@ class EtcdDriver(drivers.Driver):
                                "--listen-peer-urls", peer_url,
                                "--listen-client-urls", client_url,
                                "--advertise-client-urls", client_url],
-                              wait_for_line="listening for client requests on")
+                              wait_for_line="ready to serve client requests")
             endpoints = client_url
 
         self.putenv("ETCD_PORT", str(self.port))
@@ -89,3 +89,5 @@ class EtcdDriver(drivers.Driver):
         self.putenv("HTTP_URL", "http://localhost:%d" % self.port)
         self.putenv("URL", "etcd://localhost:%d" % self.port)
         self.putenv("ETCDCTL_ENDPOINTS", endpoints, True)
+        self.putenv("ETCDCTL_API", "3", True)
+        self._exec(["etcdctl", "endpoint", "health"])

--- a/pifpaf/tests/test_drivers.py
+++ b/pifpaf/tests/test_drivers.py
@@ -120,6 +120,8 @@ class TestDrivers(testtools.TestCase):
 
     @testtools.skipUnless(spawn.find_executable("etcd"),
                           "etcd not found")
+    @testtools.skipUnless(spawn.find_executable("etcdctl"),
+                          "etcdctl not found")
     def test_etcd(self):
         port = 4005
         peer_port = 4006
@@ -129,10 +131,12 @@ class TestDrivers(testtools.TestCase):
         self.assertEqual(str(port), os.getenv("PIFPAF_ETCD_PORT"))
         r = requests.get("http://localhost:%d/version" % port)
         self.assertEqual(200, r.status_code)
-        self._run("etcdctl cluster-health")
+        self._run("etcdctl endpoint health")
 
     @testtools.skipUnless(spawn.find_executable("etcd"),
                           "etcd not found")
+    @testtools.skipUnless(spawn.find_executable("etcdctl"),
+                          "etcdctl not found")
     def test_etcd_cluster(self):
         port = 4007
         peer_port = 4008
@@ -143,7 +147,7 @@ class TestDrivers(testtools.TestCase):
         self.assertEqual(str(port), os.getenv("PIFPAF_ETCD_PORT"))
         r = requests.get("http://localhost:%d/version" % port)
         self.assertEqual(200, r.status_code)
-        self._run("etcdctl cluster-health")
+        self._run("etcdctl endpoint health")
 
     @testtools.skipUnless(spawn.find_executable("consul"),
                           "consul not found")


### PR DESCRIPTION
This is fix to #127

In etcd v3.4 cluster, required to wait for leader election before serve client.
So, all etcd process need to exec with `wait_for_line="listening for peers on"` instead `wait_for_line="ready to serve client requests"`.

Additional:

- etcdctl use etcd v3 API (ETCDCTL_API=3) to compatible v3.0~.
- travis to use etcd v3.4.13
- Modify wait_for_line "ready to serve client requests" instead "listening for client requests on" when single process. Probably, the message is already removed. https://github.com/etcd-io/etcd/pull/11592/files#diff-22504f5e6a5f5ff5f4929b7fc571a26735f1b7746f5f143891af245e85ec4f0bL144