### PR TITLE
Remove deprecated mongo cli options

### DIFF
--- a/pifpaf/drivers/mongodb.py
+++ b/pifpaf/drivers/mongodb.py
@@ -48,8 +48,6 @@ class MongoDBDriver(drivers.Driver):
         c, _ = self._exec(
             ["mongod",
              "--nojournal",
-             "--noprealloc",
-             "--smallfiles",
              "--quiet",
              "--noauth",
              "--port", str(self.port),


### PR DESCRIPTION
these `--noprealloc` and `--smallfiles` have been removed fron mongodb 4.2, see https://docs.mongodb.com/manual/reference/configuration-options/index.html#removed-mmapv1-options