### PR TITLE
ceph: auth_allow_insecure_global_id_reclaim and mon_warn_on_pool_no_redundancy to false 

### DIFF
--- a/pifpaf/drivers/ceph.py
+++ b/pifpaf/drivers/ceph.py
@@ -130,6 +130,9 @@ mon pg warn min per osd = 0
 mon data avail warn = 2
 mon data avail crit = 1
 
+# Ceph CVE CVE-2021-20288 to prevent HEALTH_WARN
+auth allow insecure global id reclaim = false
+
 [mon.a]
 host = localhost
 mon addr = 127.0.0.1:%(port)d

--- a/pifpaf/drivers/ceph.py
+++ b/pifpaf/drivers/ceph.py
@@ -115,6 +115,9 @@ osd op threads = 10
 filestore max sync interval = 10001
 filestore min sync interval = 10000
 
+# disable POOL_NO_REDUNDANCY warning
+mon_warn_on_pool_no_redundancy = false
+
 %(extra)s
 
 journal_aio = false


### PR DESCRIPTION
This is for Ceph CVE-2021-20288 to prevent it from
being stuck in HEALTH_WARN.

Issue: https://github.com/jd/pifpaf/issues/148