### PR TITLE
Drop old Gnocchi support

### DIFF
--- a/pifpaf/drivers/gnocchi.py
+++ b/pifpaf/drivers/gnocchi.py
@@ -16,7 +16,6 @@ import shutil
 import urllib.parse
 import uuid
 from distutils import spawn
-from distutils import version
 
 import click
 
@@ -193,32 +192,7 @@ url = %s""" % (self.debug,
                           wait_for_line=("(Resource .* already exists"
                                          "|Created resource )"))
 
-        _, v = self._exec(["gnocchi-api", "--", "--version"], stdout=True)
-        v = version.LooseVersion(os.fsdecode(v).strip())
-        if v < version.LooseVersion("4.1.0"):
-            LOG.debug("gnocchi version: %s, running uwsgi manually for api", v)
-            args = [
-                "uwsgi",
-                "--http", "localhost:%d" % self.port,
-                "--wsgi-file", spawn.find_executable("gnocchi-api"),
-                "--master",
-                "--die-on-term",
-                "--lazy-apps",
-                "--processes", "4",
-                "--no-orphans",
-                "--enable-threads",
-                "--chdir", self.tempdir,
-                "--add-header", "Connection: close",
-                "--pyargv", "--config-file=%s" % conffile,
-            ]
-
-            virtual_env = os.getenv("VIRTUAL_ENV")
-            if virtual_env is not None:
-                args.extend(["-H", virtual_env])
-        else:
-            LOG.debug("gnocchi version: %s, running gnocchi-api", v)
-            args = ["gnocchi-api", "--config-file=%s" % conffile]
-
+        args = ["gnocchi-api", "--config-file=%s" % conffile]
         c, _ = self._exec(args,
                           wait_for_line=r"WSGI app 0 \(mountpoint=''\) ready")
         self.addCleanup(self._kill, c)


### PR DESCRIPTION
The distutils version code is deprecated and
we also don't support older version of Gnocchi.

The distutils version code cannot parse values like
4.4.0-dev398 and is causing error because of that.