### PR TITLE
Follow PEP517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["pbr>=5.10.0", "setuptools>=65.3.0"]
+build-backend = "pbr.build"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = pifpaf
-home-page = https://github.com/jd/pifpaf
+home_page = https://github.com/jd/pifpaf
 summary = Suite of tools and fixtures to manage daemons for testing
-description-file = README.rst
+description_file = README.rst
 author = Julien Danjou
-author-email = julien@danjou.info
+author_email = julien@danjou.info
 classifier =
     Intended Audience :: Information Technology
     License :: OSI Approved :: Apache Software License


### PR DESCRIPTION
This PR adds `pyproject.toml` to follow PEP517. The `pyproject.toml` is copied from https://docs.openstack.org/pbr/latest/user/using.html#pyproject-toml

This PR also fixes setuptools warnings; deprecated key names.

Fixes #154 and #155.