### PR TITLE
Enable the use of pifpaf run mysql with root users

### DIFF
--- a/pifpaf/drivers/mysql.py
+++ b/pifpaf/drivers/mysql.py
@@ -27,16 +27,7 @@ class MySQLDriver(drivers.Driver):
         os.mkdir(datadir)
         os.mkdir(tempdir)
 
-        c, out = self._exec(["whoami"], stdout=True, ignore_failure=True,
-                            path=["/usr/libexec"])
-
-        if isinstance(out, bytes):
-            out = out.decode('UTF-8')
-
-        if not isinstance(out, str):
-            out = str(out)
-
-        mysql_user_to_use = out.strip()
+        mysql_user_to_use = os.getlogin()
 
         c, _ = self._exec(["mysqld",
                            "--no-defaults",


### PR DESCRIPTION
This patch enabled Pifpaf to be used directly by root users to run MySQL database. Otherwise, an error is thrown.