### PR TITLE
Change local import of swift to absolute from top-level package

### DIFF
--- a/pifpaf/drivers/templates/swift/sitecustomize.py
+++ b/pifpaf/drivers/templates/swift/sitecustomize.py
@@ -1,3 +1,3 @@
-from swift.common import utils
+from pifpaf.drivers.templates.swift.common import utils
 utils.SWIFT_CONF_FILE = '{{ TMP_DIR }}/swift.conf'
 print("started")


### PR DESCRIPTION
It's better to use absolute import. By the way, it allows you to import pifpaf.drivers.templates.swift.sitecustomize