### PR TITLE
Allow the RedisDriver to launch a Redis Cluster.

### DIFF
--- a/pifpaf/drivers/redis.py
+++ b/pifpaf/drivers/redis.py
@@ -72,7 +72,7 @@ class RedisDriver(drivers.Driver):
         tempdir = self.tempdir
         if cluster:
             configuration += "cluster-enabled yes\n"
-            configuration += "cluster-config-file nodes%d.conf\n" % port 
+            configuration += "cluster-config-file nodes%d.conf\n" % port
             tempdir = os.path.join(self.tempdir, str(port))
             os.mkdir(tempdir)
         configuration += "dir %s\n" % tempdir
@@ -81,16 +81,19 @@ class RedisDriver(drivers.Driver):
             stdin=configuration.encode("ascii"),
             wait_for_line="eady to accept connections",
         )
-        
+
         self._process[port] = c
         self.addCleanup(self.kill_redis_server, port, ignore_not_exists=True)
         return port
 
-    def kill_redis_server(self, port, signal=signal.SIGTERM, ignore_not_exists=False):
-        
+    def kill_redis_server(
+        self, port, signal=signal.SIGTERM, ignore_not_exists=False
+    ):
         if port not in self._process:
             if not ignore_not_exists:
-                raise RuntimeError("no redis server with port %d not started" % port)
+                raise RuntimeError(
+                    "no redis server with port %d not started" % port
+                )
             return
 
         c = self._process.pop(port)
@@ -107,7 +110,12 @@ class RedisDriver(drivers.Driver):
             self.spawn_redis_server(cluster=True),
         ]
         nodes_list = ["127.0.0.1:%d" % port for port in ports]
-        cmd = ["redis-cli", "--cluster-yes", "--cluster", "create"] + nodes_list
+        cmd = [
+            "redis-cli",
+            "--cluster-yes",
+            "--cluster",
+            "create",
+        ] + nodes_list
         self._exec(cmd)
         return ports
 
@@ -128,7 +136,8 @@ sentinel monitor pifpaf localhost %d 1"""
                     )
 
                 c, _ = self._exec(
-                    ["redis-sentinel", cfg], wait_for_line=r"# Sentinel (runid|ID) is"
+                    ["redis-sentinel", cfg],
+                    wait_for_line=r"# Sentinel (runid|ID) is",
                 )
 
                 self.addCleanup(self._kill, c)
@@ -137,4 +146,3 @@ sentinel monitor pifpaf localhost %d 1"""
         self.putenv("REDIS_PORT", str(p1))
         self.url = "redis://localhost:%d" % p1
         self.putenv("URL", self.url)
-        

--- a/pifpaf/drivers/redis.py
+++ b/pifpaf/drivers/redis.py
@@ -11,66 +11,125 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import os
+import signal
 
 from pifpaf import drivers
 
 
 class RedisDriver(drivers.Driver):
-
     DEFAULT_PORT = 6379
     DEFAULT_PORT_SENTINEL = 6380
 
-    def __init__(self, port=DEFAULT_PORT,
-                 sentinel=False, sentinel_port=DEFAULT_PORT_SENTINEL,
-                 **kwargs):
+    def __init__(
+        self,
+        port=DEFAULT_PORT,
+        sentinel=False,
+        sentinel_port=DEFAULT_PORT_SENTINEL,
+        cluster=False,
+        **kwargs
+    ):
         """Create a new Redis server."""
         super(RedisDriver, self).__init__(**kwargs)
         self.port = port
         self.sentinel = sentinel
         self.sentinel_port = sentinel_port
+        self.cluster = cluster
+        self._process = {}
+        self._next_port = itertools.count(self.port)
 
     @classmethod
     def get_options(cls):
         return [
-            {"param_decls": ["--port"],
-             "type": int,
-             "default": cls.DEFAULT_PORT,
-             "help": "port to use for Redis"},
-            {"param_decls": ["--sentinel"],
-             "is_flag": True,
-             "help": "activate Redis sentinel"},
-            {"param_decls": ["--sentinel-port"],
-             "type": int,
-             "default": cls.DEFAULT_PORT_SENTINEL,
-             "help": "port to use for Redis sentinel"},
+            {
+                "param_decls": ["--port"],
+                "type": int,
+                "default": cls.DEFAULT_PORT,
+                "help": "port to use for Redis",
+            },
+            {
+                "param_decls": ["--sentinel"],
+                "is_flag": True,
+                "help": "activate Redis sentinel",
+            },
+            {
+                "param_decls": ["--sentinel-port"],
+                "type": int,
+                "default": cls.DEFAULT_PORT_SENTINEL,
+                "help": "port to use for Redis sentinel",
+            },
+            {
+                "param_decls": ["--cluster"],
+                "is_flag": True,
+                "help": "create a 3 HA redis cluster",
+            },
         ]
+
+    def spawn_redis_server(self, cluster=False):
+        port = next(self._next_port)
+        c, _ = self._exec(
+            ["redis-server", "-"],
+            stdin=(
+                "dir %s\nport %d\ncluster-enabled %s\ncluster-config-file nodes%d.conf"
+                % (self.tempdir, port, "yes" if cluster else "no", port)
+            ).encode("ascii"),
+            wait_for_line="eady to accept connections",
+        )
+        self._process[port] = c
+        self.addCleanup(self.kill_node, port, ignore_not_exists=True)
+        return port
+
+    def kill_redis_server(self, port, signal=signal.SIGTERM, ignore_not_exists=False):
+        if port not in self._process:
+            if not ignore_not_exists:
+                raise RuntimeError("no redis server with port %d not started" % port)
+            return
+
+        c = self._process.pop(port)
+        try:
+            os.killpg(c.pid, signal)
+            os.waitpid(c.pid, 0)
+        except OSError:
+            pass
+
+    def setup_cluster(self):
+        ports = [
+            self.spawn_redis_server(cluster=True),
+            self.spawn_redis_server(cluster=True),
+            self.spawn_redis_server(cluster=True),
+        ]
+        nodes_list = " ".join(["localhost:%d" % port for port in ports])
+        self._exec(
+            ["redis-cli", "--cluster-yes", "--cluster", "create"].extend(nodes_list),
+            wait_for_line="[OK] All nodes agree about slots configuration.",
+        )
+        return ports
 
     def _setUp(self):
         super(RedisDriver, self)._setUp()
-        c, _ = self._exec(
-            ["redis-server", "-"],
-            stdin=("dir %s\nport %d\n"
-                   % (self.tempdir, self.port)).encode('ascii'),
-            wait_for_line="eady to accept connections")
-
-        if self.sentinel:
-            cfg = os.path.join(self.tempdir, "redis-sentinel.conf")
-            with open(cfg, "w") as f:
-                f.write("""dir %s
+        if self.cluster:
+            p1 = self.setup_cluster()[0]
+        else:
+            p1 = self.spawn_redis_server()
+            if self.sentinel:
+                cfg = os.path.join(self.tempdir, "redis-sentinel.conf")
+                with open(cfg, "w") as f:
+                    f.write(
+                        """dir %s
 port %d
 sentinel monitor pifpaf localhost %d 1"""
-                        % (self.tempdir, self.sentinel_port, self.port))
+                        % (self.tempdir, self.sentinel_port, self.port)
+                    )
 
-            c, _ = self._exec(
-                ["redis-sentinel", cfg],
-                wait_for_line=r"# Sentinel (runid|ID) is")
+                c, _ = self._exec(
+                    ["redis-sentinel", cfg], wait_for_line=r"# Sentinel (runid|ID) is"
+                )
 
-            self.addCleanup(self._kill, c)
+                self.addCleanup(self._kill, c)
 
-            self.putenv("REDIS_SENTINEL_PORT",
-                        str(self.sentinel_port))
+                self.putenv("REDIS_SENTINEL_PORT", str(self.sentinel_port))
 
-        self.putenv("REDIS_PORT", str(self.port))
-        self.url = "redis://localhost:%d" % self.port
+        self.putenv("REDIS_PORT", str(p1))
+        self.url = "redis://localhost:%d" % p1
         self.putenv("URL", self.url)

--- a/pifpaf/tests/test_drivers.py
+++ b/pifpaf/tests/test_drivers.py
@@ -284,6 +284,14 @@ class TestDrivers(testtools.TestCase):
         self.assertEqual("6380", os.getenv("PIFPAF_REDIS_SENTINEL_PORT"))
         self._run("redis-cli -p %d sentinel master pifpaf" % f.sentinel_port)
 
+    def test_redis_cluster(self):
+        port = 6386
+        f = self.useFixture(redis.RedisDriver(port=port, cluster=True))
+        self.assertEqual("redis://localhost:%d" % port,
+                         os.getenv("PIFPAF_URL"))
+        self.assertEqual(str(port), os.getenv("PIFPAF_REDIS_PORT"))
+        self._run("redis-cli -p %d llen pifpaf" % f.port)
+
     @testtools.skipUnless(spawn.find_executable(
         "zkServer.sh", path=":".join(zookeeper.ZooKeeperDriver.PATH)),
         "ZooKeeper not found")


### PR DESCRIPTION
The current `RedisDriver` didn't have the ability to launch a 3 node HA Redis Cluster. 
This PR ain to add this functionality. 
Note that Sentinel and Cluster are exclusive. This is reflected in the code. 