### PR TITLE
Drop runtime dependency on setuptools for entrypoint enumeration and version parsing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     click
     jinja2
     fixtures
+    packaging
     psutil
     xattr ; sys_platform != 'win32'
 


### PR DESCRIPTION
- globally replace pkg_resources.parse_version with non-aliased class

  For a long time now, pkg_resources has depended on a (possibly vendored) copy of the packaging module, and imports `Version` as `parse_version`.

  Use the original class directly. Add a direct dependency on packaging to make sure it's visibly required.

  pkg_resources is deprecated and the recommended replacement is to directly use packaging where relevant. The result is faster to load, and more guaranteed to work e.g. in environments where setuptools isn't installed by default.

- drop dependency on setuptools at runtime to enumerate entrypoints

  pkg_resources is deprecated and the recommended replacement is to use importlib.metadata where relevant. The result is faster to load, and more guaranteed to work e.g. in environments where setuptools isn't installed by default.