### PR TITLE
Update supported python versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ summary = Suite of tools and fixtures to manage daemons for testing
 description_file = README.rst
 author = Julien Danjou
 author_email = julien@danjou.info
+python_requires = >=3.8
 classifier =
     Intended Audience :: Information Technology
     License :: OSI Approved :: Apache Software License
@@ -14,6 +15,7 @@ classifier =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Testing
 
 [options]


### PR DESCRIPTION
This library works without any problems with Python 3.11 so far. So we can update the classifiers.

Also, adds python_requires to block installation into Python < 3.8.