### PR TITLE
Redis: Add password to URL environment

### DIFF
--- a/pifpaf/drivers/redis.py
+++ b/pifpaf/drivers/redis.py
@@ -86,5 +86,8 @@ sentinel monitor pifpaf localhost %d 1
                         str(self.sentinel_port))
 
         self.putenv("REDIS_PORT", str(self.port))
-        self.url = "redis://localhost:%d" % self.port
+        if self.password:
+            self.url = "redis://:%s@localhost:%d" % (self.password, self.port)
+        else:
+            self.url = "redis://localhost:%d" % self.port
         self.putenv("URL", self.url)

--- a/pifpaf/tests/test_drivers.py
+++ b/pifpaf/tests/test_drivers.py
@@ -278,7 +278,7 @@ class TestDrivers(testtools.TestCase):
     def test_redis_with_password(self):
         port = 6384
         f = self.useFixture(redis.RedisDriver(port=port, password='secrete'))
-        self.assertEqual("redis://localhost:%d" % port,
+        self.assertEqual("redis://:secrete@localhost:%d" % port,
                          os.getenv("PIFPAF_URL"))
         self.assertEqual(str(port), os.getenv("PIFPAF_REDIS_PORT"))
         self._run("redis-cli -p %d -a secrete llen pifpaf" % f.port)
@@ -301,7 +301,7 @@ class TestDrivers(testtools.TestCase):
         port = 6385
         f = self.useFixture(redis.RedisDriver(sentinel=True, port=port,
                                               password='secrete'))
-        self.assertEqual("redis://localhost:%d" % port,
+        self.assertEqual("redis://:secrete@localhost:%d" % port,
                          os.getenv("PIFPAF_URL"))
         self.assertEqual(str(port), os.getenv("PIFPAF_REDIS_PORT"))
         self.assertEqual("6380", os.getenv("PIFPAF_REDIS_SENTINEL_PORT"))


### PR DESCRIPTION
This is follow-up of d37bae254a627c0aef2e760b697336080193681f and ensures the password value is included in the url, presented by the URL environment, so that the value can be looked up.