### PR TITLE
Use squash merge method for mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,7 @@ pull_request_rules:
   - name: automatic merge
     actions:
       queue:
-        method: merge
+        method: squash
         name: default
     conditions:
       - label!=work-in-progress


### PR DESCRIPTION
Mergify is blocked with the error:
    
```
      Merge commits are not allowed on this repository.
      The repository configuration doesn't allow merge commits.
      The merge method configured in Mergify configuration must be
      allowed in the repository configuration settings.
```