### PR TITLE
Redis: Use IP address in sentinel configuration

### DIFF
--- a/pifpaf/drivers/redis.py
+++ b/pifpaf/drivers/redis.py
@@ -67,7 +67,7 @@ port %d
             cfg = os.path.join(self.tempdir, "redis-sentinel.conf")
             sentinel_conf = """dir %s
 port %d
-sentinel monitor pifpaf localhost %d 1
+sentinel monitor pifpaf 127.0.0.1 %d 1
 """ % (self.tempdir, self.sentinel_port, self.port)
             if self.password:
                 sentinel_conf += (


### PR DESCRIPTION
Sentinel supports hostnames since Redis 6.2, and the support should be explicitly enabled. See [1] for details.

[1] https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#ip-addresses-and-dns-names

Fixes #173