### PR TITLE
Replace call to deprecated method Thread.setDaemon()

### DIFF
--- a/pifpaf/drivers/__init__.py
+++ b/pifpaf/drivers/__init__.py
@@ -230,7 +230,7 @@ class Driver(fixtures.Fixture):
             # Continue to read
             t = threading.Thread(target=self._read_in_bg,
                                  args=(app, c.pid, c.stdout,))
-            t.setDaemon(True)
+            t.daemon = True
             t.start()
             # Store the thread ref into the Process() to be able
             # to clean it


### PR DESCRIPTION
This method was deprecated in Python 3.10, set the Thread.daemon attribute directly instead.

See: https://github.com/python/cpython/pull/25174