### PR TITLE
Fix long description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = pifpaf
 home_page = https://github.com/jd/pifpaf
 summary = Suite of tools and fixtures to manage daemons for testing
 description_file = README.rst
+long_description_content_type = text/x-rst
 author = Julien Danjou
 author_email = julien@danjou.info
 python_requires = >=3.8

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
 import setuptools
 
-setuptools.setup()
+setuptools.setup(
+    long_description=open('README.rst').read(),
+)


### PR DESCRIPTION
twine check was complaining and it looks
like it won't render the readme in pypi
without this.