### PR TITLE
Fix CI and test using Ubuntu 24.04 and Python 3.12

### DIFF
--- a/.github/workflows/pifpaf.yaml
+++ b/.github/workflows/pifpaf.yaml
@@ -15,12 +15,14 @@ jobs:
     strategy:
       matrix:
         env:
-          - py310
+          - py39
+          - py311
+          - py312
           - pep8
           - build
     steps:
       - uses: actions/checkout@v4
-      - run: sudo chown -R 1000:1000 $GITHUB_WORKSPACE
+      - run: sudo chown -R 1010:1010 $GITHUB_WORKSPACE
       - uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/pifpaf.yaml
+++ b/.github/workflows/pifpaf.yaml
@@ -12,6 +12,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
@@ -11,7 +11,7 @@ RUN apt-get update -y && apt-get install -qy gnupg software-properties-common
 RUN add-apt-repository -y ppa:deadsnakes/ppa
 RUN apt-get -qq update -y \
     && apt-get install -y mysql-server redis-server zookeeper nodejs npm ceph librados-dev \
-          python3 python3-dev python3-pip python3.9 python3.9-dev \
+          python3 python3-dev python3-pip python3-virtualenv python3.9 python3.9-dev python3.9-distutils python3.11 python3.11-dev \
           gcc liberasurecode-dev liberasurecode1 postgresql libpq-dev python3-rados git wget memcached \
     && rm -rf /var/lib/apt/lists/*
 
@@ -30,10 +30,12 @@ RUN wget https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd
     && ln -s /opt/etcd-v${ETCD_VERSION}-linux-amd64/etcd /usr/local/bin/etcd \
     && ln -s /opt/etcd-v${ETCD_VERSION}-linux-amd64/etcdctl /usr/local/bin/etcdctl
 
-RUN pip install -U tox
-
-RUN useradd -ms /bin/bash pifpaf
+RUN groupadd --gid 1010 pifpaf
+RUN useradd --uid 1010 --gid 1010 -ms /bin/bash pifpaf
 USER pifpaf
 RUN mkdir /home/pifpaf/tmpxattr
 ENV TMP_FOR_XATTR=/home/pifpaf/tmpxattr
+RUN python3 -m virtualenv /home/pifpaf/venv
+ENV PATH="/home/pifpaf/venv/bin:$PATH"
+RUN pip install tox
 WORKDIR /home/pifpaf/pifpaf

--- a/pifpaf/drivers/ceph.py
+++ b/pifpaf/drivers/ceph.py
@@ -51,8 +51,12 @@ class CephDriver(drivers.Driver):
 
         _, version = self._exec(["ceph", "--version"], stdout=True)
         version = version.decode("ascii").split()[2]
+        # NOTE(tobias-urdin): Ceph versions on Ubuntu can have a
+        # tilde sign in the version like 19.2.0~git20240301.4c76c50
+        # because they've built it before it was released with their
+        # own versioning, packaging cannot handle that.
+        version = str(version).split("~")[0]
         version = packaging.version.Version(version)
-
         if version < packaging.version.Version("12.0.0"):
             extra = """
 mon_osd_nearfull_ratio = 1

--- a/pifpaf/tests/test_drivers.py
+++ b/pifpaf/tests/test_drivers.py
@@ -68,6 +68,16 @@ unkillable = os.path.join(
     "unkillable.py")
 
 
+# NOTE(tobias-urdin): The rados python bindings is only installed
+# for the python version that the distro ships.
+def _has_rados():
+    try:
+        import rados  # noqa
+        return True
+    except ImportError:
+        return False
+
+
 class TestDrivers(testtools.TestCase):
     def setUp(self):
         super(TestDrivers, self).setUp()
@@ -441,6 +451,7 @@ class TestDrivers(testtools.TestCase):
         r = requests.get("http://localhost:%d/" % port)
         self.assertEqual(200, r.status_code)
 
+    @testtools.skipUnless(_has_rados(), "Rados not found")
     @testtools.skipUnless(shutil.which("gnocchi-api"),
                           "Gnocchi not found")
     @testtools.skipUnless(shutil.which("ceph-mon"),
@@ -502,6 +513,7 @@ class TestDrivers(testtools.TestCase):
         r = requests.get(os.getenv("PIFPAF_KEYSTONE_HTTP_URL"))
         self.assertEqual(300, r.status_code)
 
+    @testtools.skipUnless(_has_rados(), "Rados not found")
     @testtools.skipUnless(shutil.which("ceph-mon"),
                           "Ceph Monitor not found")
     @testtools.skipUnless(shutil.which("ceph-osd"),

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps = .[test,ceph,gnocchi]
 passenv = TMPDIR_FOR_XATTR
 setenv =
   PYTHONPATH={envsitepackagesdir}:/usr/lib/python3/dist-packages/
+  VIRTUALENV_SETUPTOOLS=bundle
 commands = stestr run {posargs}
 
 [testenv:venv]


### PR DESCRIPTION
* Fixes the CI
* Starts using Ubuntu 24.04 for testing
* Tests using Python 3.9, Python 3.11 and Python 3.12
* Fix to handle tilde sign in Ceph version
* Skip Ceph jobs when rados bindings is not available from distro package for that python version
* Set job timeout to 30 minutes so that we dont have to wait 6 hours or cancel workflows that are stuck