### PR TITLE
Fix list command names from importlib

### DIFF
--- a/pifpaf/__main__.py
+++ b/pifpaf/__main__.py
@@ -73,6 +73,16 @@ else:
     DAEMONS = importlib.metadata.entry_points()['pifpaf.daemons']
 
 
+def _daemons_names():
+    names = []
+    if hasattr(DAEMONS, 'names'):
+        names = DAEMONS.names
+    else:
+        for i in DAEMONS:
+            names.append(i.name)
+    return names
+
+
 @click.group()
 @click.option('--verbose/--quiet', help="Print mode details.")
 @click.option('--debug', help="Show tracebacks on errors.", is_flag=True)
@@ -119,14 +129,14 @@ def main(ctx, verbose=False, debug=False, log_file=None,
 
 @main.command(name="list")
 def drivers_list():
-    for n in DAEMONS.keys():
+    for n in _daemons_names():
         click.echo(n)
 
 
 class RunGroup(click.MultiCommand):
     @staticmethod
     def list_commands(ctx):
-        return DAEMONS.keys()
+        return _daemons_names()
 
     def get_command(self, ctx, name):
         params = [click.Argument(["command"], nargs=-1)]

--- a/pifpaf/tests/test_cli.py
+++ b/pifpaf/tests/test_cli.py
@@ -147,6 +147,14 @@ class TestCli(testtools.TestCase):
             b"\"memcached://localhost:11217;memcached://localhost:11218\";",
             env[b"export PIFPAF_URLS"])
 
+    def test_list_command(self):
+        c = subprocess.Popen(["pifpaf", "list"],
+                             bufsize=0,
+                             stdout=subprocess.PIPE)
+        (stdout, stderr) = c.communicate()
+        self.assertEqual(0, c.wait())
+        self.assertIn(b'memcached', stdout)
+
     def test_non_existing_command(self):
         # Keep PATH to just the one set by tox to run pifpaf
         self.useFixture(fixtures.EnvironmentVariable(


### PR DESCRIPTION
The compatibility code for importlib.metadata
returned names was not correct.

Closes: #188