### PR TITLE
Valkey:  Redis: Use IP address in sentinel configuration

### DIFF
--- a/pifpaf/drivers/valkey.py
+++ b/pifpaf/drivers/valkey.py
@@ -67,7 +67,7 @@ port %d
             cfg = os.path.join(self.tempdir, "valkey-sentinel.conf")
             sentinel_conf = """dir %s
 port %d
-sentinel monitor pifpaf localhost %d 1
+sentinel monitor pifpaf 127.0.0.1 %d 1
 """ % (self.tempdir, self.sentinel_port, self.port)
             if self.password:
                 sentinel_conf += (


### PR DESCRIPTION
To use the hostname in Valkey, the support should be explicitly enabled[1].

[1] https://valkey.io/topics/sentinel/

```
Enabling the resolve-hostnames global configuration allows Sentinel to accept host names:
```

We fixed the same problem with redis driver in the past[2].

[2] 6cbb3fcccb3f4209c55fa3558f0c325a45c33b87