### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,14 +6,13 @@ description_file = README.rst
 long_description_content_type = text/x-rst
 author = Julien Danjou
 author_email = julien@danjou.info
-python_requires = >=3.8
+python_requires = >=3.9
 classifier =
     Intended Audience :: Information Technology
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11


### PR DESCRIPTION
Python 3.8 already reached its EOL and is no longer tested in CI.