### PR TITLE
Allow drivers requiring extended attributes to use any xattr implementation

### DIFF
--- a/pifpaf/drivers/__init__.py
+++ b/pifpaf/drivers/__init__.py
@@ -75,8 +75,13 @@ class Driver(fixtures.Fixture):
         xattr_supported = False
         if xattr is not None:
             try:
-                x = xattr.xattr(testfile)
-                x[b"user.test"] = b"test"
+                # PyPI: xattr
+                if hasattr(xattr, 'xattr'):
+                    x = xattr.xattr(testfile)
+                    x[b"user.test"] = b"test"
+                # PyPI: pyxattr
+                else:
+                    xattr.setxattr(testfile, 'user.test', 'test')
             except (OSError, IOError) as e:
                 if e.errno != 95:
                     raise


### PR DESCRIPTION
There are two reasonably popular implementations of "xattr" on PyPI:

- xattr
- pyxattr

They both provide the same importable name, "import xattr", but provide different APIs once you do import it. There can only be one installed to any given python environment. Detect which one is available and utilize its API, rather than assume that the one preferred by this package's install_requires is the one actually installed in the current environment.

This aids people in manually crafting environments containing a mix of packages if any of them require pyxattr specifically. Unfortunately PyPA metadata standards do not support boolean "OR" dependency operators, so this is primarily useful to people installing software using a non-python package manager (such as a linux distro package manager).