### PR TITLE
Capture alternative marker in Redis Sentinel logs

### DIFF
--- a/pifpaf/drivers/redis.py
+++ b/pifpaf/drivers/redis.py
@@ -78,7 +78,7 @@ sentinel monitor pifpaf 127.0.0.1 %d 1
 
             c, _ = self._exec(
                 ["redis-sentinel", cfg],
-                wait_for_line=r"# Sentinel (runid|ID) is")
+                wait_for_line=r"[#*] Sentinel (runid|ID) is")
 
             self.addCleanup(self._kill, c)
 


### PR DESCRIPTION
Log lines can start with `"*"` instead of `"#"`.

Reported on Redis 7.2.7