### PR TITLE
Add /usr/libexec/rabbitmq to RabbitMQ search paths

### DIFF
--- a/pifpaf/drivers/rabbitmq.py
+++ b/pifpaf/drivers/rabbitmq.py
@@ -37,6 +37,7 @@ class RabbitMQDriver(drivers.Driver):
         self.password = password
         self.cluster = cluster
         self._path = ["/usr/lib/rabbitmq/bin/",
+                      "/usr/libexec/rabbitmq/",
                       "/usr/local/sbin"]
         self._process = {}
         self._ports = {}


### PR DESCRIPTION
Executables in /usr/sbin are wrappers that require superuser privileges
to run.

Binaries in /usr/libexec/rabbitmq can be run as a non-privileged user.