### PR TITLE
Remove "wheel" dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
It comes from a historical mistake in setuptools documentation that
listed wheel dependency unnecessarily:
https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a