### PR TITLE
redis/valkey: Adopt to recent log format from sentinel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ ARG ETCD_VERSION=3.4.13
 RUN apt-get update -y && apt-get install -qy gnupg software-properties-common
 RUN add-apt-repository -y ppa:deadsnakes/ppa
 RUN apt-get -qq update -y \
-    && apt-get install -y mysql-server redis-server zookeeper nodejs npm ceph librados-dev \
+    && apt-get install -y mysql-server redis-server redis-sentinel valkey-server valkey-sentinel \
+          zookeeper nodejs npm ceph librados-dev \
           python3 python3-dev python3-pip python3-virtualenv \
           python3.10 python3.10-dev python3.10-distutils \
           python3.11 python3.11-dev \

--- a/pifpaf/drivers/redis.py
+++ b/pifpaf/drivers/redis.py
@@ -78,7 +78,7 @@ sentinel monitor pifpaf 127.0.0.1 %d 1
 
             c, _ = self._exec(
                 ["redis-sentinel", cfg],
-                wait_for_line=r"# Sentinel (runid|ID) is")
+                wait_for_line=r"[#\*] Sentinel (runid|ID) is")
 
             self.addCleanup(self._kill, c)
 

--- a/pifpaf/drivers/valkey.py
+++ b/pifpaf/drivers/valkey.py
@@ -78,7 +78,7 @@ sentinel monitor pifpaf 127.0.0.1 %d 1
 
             c, _ = self._exec(
                 ["valkey-sentinel", cfg],
-                wait_for_line=r"# Sentinel (runid|ID) is")
+                wait_for_line=r"[#\*] Sentinel (runid|ID) is")
 
             self.addCleanup(self._kill, c)
 


### PR DESCRIPTION
Since Redis 7.2, the log line used to ensure the sentinel is started is emitted with a different prefix. Make sure that both of the old one and new one are accepted.

Fixes #202