### PR TITLE
Bump etcd to 3.5.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV TZ=Etc/UTC
 ARG INFLUXDB_VERSION=0.13.0
 ARG SCALA_VERSION=2.12
 ARG KAFKA_VERSION=2.6.0
-ARG ETCD_VERSION=3.4.13
+ARG ETCD_VERSION=3.5.23
 
 RUN apt-get update -y && apt-get install -qy gnupg software-properties-common
 RUN add-apt-repository -y ppa:deadsnakes/ppa


### PR DESCRIPTION
The etcd project maintains release branches for the current version and pevious release[1]. Because 3.6.0 was already released, 3.4.x is no longer supported.
Bump it to the latest bug fix release of 3.5.x .

This follows the change earlier made in tempest.

[1] https://etcd.io/docs/v3.6/op-guide/versioning/