### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/pifpaf.yaml
+++ b/.github/workflows/pifpaf.yaml
@@ -19,6 +19,7 @@ jobs:
           - py310
           - py311
           - py312
+          - py313
           - pep8
           - build
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -qq update -y \
           python3 python3-dev python3-pip python3-virtualenv \
           python3.10 python3.10-dev python3.10-distutils \
           python3.11 python3.11-dev \
+          python3.13 python3.13-dev \
           gcc liberasurecode-dev liberasurecode1 postgresql libpq-dev python3-rados git wget memcached \
     && rm -rf /var/lib/apt/lists/*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifier =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Software Development :: Testing
 
 [options]
@@ -39,6 +40,7 @@ test =
     stestr
     testtools
     mock
+    legacy-cgi; python_version>='3.13'
 gnocchi =
     uwsgi
 


### PR DESCRIPTION
Python 3.13 was already released and is now available in Ubuntu Noble.